### PR TITLE
note path as cli arg

### DIFF
--- a/clean.rb
+++ b/clean.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require_relative './utils.rb'
+
 def read_markdown_directory(raw_directory)
   links = []
   rbfiles = File.join("**", "*.md")
@@ -18,10 +20,10 @@ def clean_empty_files(raw_directory, links_list)
         File.delete(File.join(raw_directory,filename))
       end
     end
-  end 
+  end
 end
 
-notes_path = "#{ENV['HOME']}/Notes/"
+notes_path = get_notes_path_from_cli_args()
 
 links_list = read_markdown_directory(notes_path)
 clean_empty_files(notes_path, links_list)

--- a/journal.rb
+++ b/journal.rb
@@ -1,9 +1,12 @@
 #!/usr/bin/env ruby
 require 'date'
 
-filepath = "#{ENV['HOME']}/Notes/"
+require_relative './utils.rb'
+
+filepath = get_notes_path_from_cli_args()
+
 today = Date.today
-filename = today.strftime('%Y-%m-%d.md')
+day_filename = today.strftime('%Y-%m-%d.md')
 last_year = today.prev_year.strftime('%Y-%m-%d')
 this_week = today.strftime('%G-W%V')
 this_week_monday = today - (today.cwday-1)
@@ -29,9 +32,10 @@ journal_template = <<~JOURNAL
   - 
 JOURNAL
 
-File.open("#{filepath}#{filename}", 'a') { |f| f.write "#{journal_template}" }
+day_filepath = filepath + day_filename
+File.open(day_filepath, 'a') { |f| f.write "#{journal_template}" }
 
-puts "Wrote daily template to #{filepath}#{filename}"
+puts "Wrote daily template to #{day_filepath}"
 
 weekly_template = <<~WEEKLY
   # #{this_week}
@@ -67,7 +71,8 @@ weekly_template = <<~WEEKLY
       - 
 WEEKLY
 
-unless File.exist?("#{filepath}#{week_filename}") 
-  File.open("#{filepath}#{week_filename}", 'w') { |f| f.write "#{weekly_template}" }
-  puts "Wrote weekly template to #{filepath}#{week_filename}"
+week_filepath = filepath + week_filename
+unless File.exist?(week_filepath) 
+  File.open(week_filepath, 'w') { |f| f.write "#{weekly_template}" }
+  puts "Wrote weekly template to #{week_filepath}"
 end

--- a/recent.rb
+++ b/recent.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 require 'date'
 
+require_relative './utils.rb'
+
 def read_markdown_directory(raw_directory)
   contents = {}
   recent_day_range = (Date.today.prev_day(7)..Date.today)
@@ -27,12 +29,9 @@ def write_recent_file(filepath, recent_notes)
   end 
 end 
 
-notes_path = "#{ENV['HOME']}/Notes/"
+notes_path = get_notes_path_from_cli_args()
 recent_filepath = notes_path + 'RECENT.md'
 
 recent_notes = read_markdown_directory(notes_path)
 
 write_recent_file(recent_filepath, recent_notes)
-
-
-

--- a/todo.rb
+++ b/todo.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require_relative './utils.rb'
+
 def read_markdown_directory(raw_directory)
   contents = {}
   rbfiles = File.join("**", "*.md")
@@ -36,16 +38,14 @@ def write_todo_file(filepath, todo_lines)
     todo_lines.each do |filename, lines|
       file.write "## #{filename}\n\n#{lines}\n"
     end
-  end 
-end 
+  end
+end
 
-notes_path = "#{ENV['HOME']}/Notes/"
+
+notes_path = get_notes_path_from_cli_args()
 todo_filepath = notes_path + 'TODO.md'
 
 notes = read_markdown_directory(notes_path)
 todo_lines = extract_todo_lines(notes)
 
 write_simple_todo_file(todo_filepath, todo_lines)
-
-
-

--- a/utils.rb
+++ b/utils.rb
@@ -6,13 +6,11 @@ def get_notes_path_from_cli_args()
   else
     notes_path = Pathname.new("#{ENV['HOME']}/Notes/")
   end
-  
+
   if not notes_path.directory?
     Kernel.abort("Directory [#{notes_path}] does not exist.
 Please specify your notes directory as a command line argument.
    ex: ruby todo.md ~/john/my_notes")
-  else
-    puts "notes path: #{notes_path}".inspect
   end
 
   return notes_path

--- a/utils.rb
+++ b/utils.rb
@@ -1,0 +1,19 @@
+require 'pathname'
+
+def get_notes_path_from_cli_args()
+  if ARGV.length == 1
+    notes_path = Pathname.new(ARGV[0])
+  else
+    notes_path = Pathname.new("#{ENV['HOME']}/Notes/")
+  end
+  
+  if not notes_path.directory?
+    Kernel.abort("Directory [#{notes_path}] does not exist.
+Please specify your notes directory as a command line argument.
+   ex: ruby todo.md ~/john/my_notes")
+  else
+    puts "notes path: #{notes_path}".inspect
+  end
+
+  return notes_path
+end


### PR DESCRIPTION
Add a way to pass the notes path as the first arguments for the 3 scripts

Put the function in a new file that is required by the scripts.
This can be removed if you want the scripts to be standalone.

usage:
`ruby todo.rb ~/marcus/my_notes_path`

resolves #3